### PR TITLE
avoid freezing

### DIFF
--- a/primitive/src/main/java/io/atomix/primitive/session/impl/RecoveringSessionClient.java
+++ b/primitive/src/main/java/io/atomix/primitive/session/impl/RecoveringSessionClient.java
@@ -177,7 +177,9 @@ public class RecoveringSessionClient implements SessionClient {
               .build());
           this.session = proxy;
           proxy.addStateChangeListener(this::onStateChange);
-          eventListeners.forEach(proxy::addEventListener);
+          if (!eventListeners.isEmpty()) {
+            eventListeners.forEach(proxy::addEventListener);
+          }
           onStateChange(PrimitiveState.CONNECTED);
         }
         future.complete(this);


### PR DESCRIPTION
add determine statement to avoid freezing when `eventListeners` is empty